### PR TITLE
Bump coffee-react-transform version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "gulp": "~3.8.8",
     "gulp-util": "~3.0.1",
-    "coffee-react-transform": "~1.0.2",
+    "coffee-react-transform": "~2.2.1",
     "through2": "~0.6.2"
   }
 }


### PR DESCRIPTION
The old version generated javascript that gave deprecate warnings from React.

Most notably, I get a lot of `Warning: Do not pass React.DOM.div to JSX or createFactory. Use the string "div" instead.` for instance. The new version of coffee-react-transform will generate up-to-date javascript.
