### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "gulp": "~3.8.8",
     "gulp-util": "~3.0.1",
-    "coffee-react-transform": "~1.0.2",
+    "coffee-react-transform": "^3.0.1",
     "through2": "~0.6.2"
   }
 }


### PR DESCRIPTION
use old version ~1.0.2 coffee-react-transform will have cover error,
for example:render  <h1>  will conver to
React.createElement(React.DOM.h1, null, "is react SideBar 1qqq111"); ,
this will make a error component mount not defined,
update dependency to 3.01 will fixed this problem,
make a collect conver
for example
React.createElement("h1", null, "test");
